### PR TITLE
Additional supported parameters and 32-bit support

### DIFF
--- a/AWSSAMLCredentials/ClassLibrary1/AWSSAMLCredentials.csproj
+++ b/AWSSAMLCredentials/ClassLibrary1/AWSSAMLCredentials.csproj
@@ -31,16 +31,16 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AWSSDK.Core">
-      <HintPath>C:\Program Files (x86)\AWS SDK for .NET\bin\Net45\AWSSDK.Core.dll</HintPath>
+      <HintPath>$(ProgramFiles)\AWS SDK for .NET\bin\Net45\AWSSDK.Core.dll</HintPath>
     </Reference>
     <Reference Include="AWSSDK.SecurityToken">
-      <HintPath>C:\Program Files (x86)\AWS SDK for .NET\bin\Net45\AWSSDK.SecurityToken.dll</HintPath>
+      <HintPath>$(ProgramFiles)\AWS SDK for .NET\bin\Net45\AWSSDK.SecurityToken.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\WindowsPowerShell\3.0\System.Management.Automation.dll</HintPath>
+      <HintPath>$(ProgramFiles)\Reference Assemblies\Microsoft\WindowsPowerShell\3.0\System.Management.Automation.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
Made a minor change in the project manifest to utilise "Program Files (x86)" on 64-bit systems, and "Program Files" on 32-bit systems

Added functionality to allow a user to specify the desired username, password, domain and IAM role ARN as parameters to simplify usage of this module within automated processes (referencing an IAM role by ARN is more consistent than referencing the index of a role)